### PR TITLE
Fetch and display skill logs data

### DIFF
--- a/src/models/ISkillLogItem.ts
+++ b/src/models/ISkillLogItem.ts
@@ -1,0 +1,11 @@
+export interface ISkillLogItem {
+  Id: number;
+  EmployeeEmail: string;
+  Skills: string;
+  ExpectedProficiency: string;
+  ActualProficiency: string;
+  ActionPlan: string;
+  Timeline: string;
+  SkillGap: string;
+  Comments: string;
+}

--- a/src/webparts/skillMatrix/SkillMatrixWebPart.ts
+++ b/src/webparts/skillMatrix/SkillMatrixWebPart.ts
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import * as ReactDom from 'react-dom';
+import { BaseClientSideWebPart } from '@microsoft/sp-webpart-base';
+import { sp } from '@pnp/sp/presets/all';
+
+import SkillMatrix from './components/SkillMatrix';
+import { ISkillMatrixProps } from './components/ISkillMatrixProps';
+
+export interface ISkillMatrixWebPartProps {}
+
+export default class SkillMatrixWebPart extends BaseClientSideWebPart<ISkillMatrixWebPartProps> {
+  protected async onInit(): Promise<void> {
+    await super.onInit();
+
+    // Configure PnPjs to use SPFx context
+    sp.setup({
+      spfxContext: this.context,
+    });
+  }
+
+  public render(): void {
+    const element: React.ReactElement<ISkillMatrixProps> = React.createElement(
+      SkillMatrix,
+      {
+        siteUrl: this.context.pageContext.web.absoluteUrl,
+      }
+    );
+
+    ReactDom.render(element, this.domElement);
+  }
+
+  protected onDispose(): void {
+    ReactDom.unmountComponentAtNode(this.domElement);
+  }
+}

--- a/src/webparts/skillMatrix/components/ISkillMatrixProps.ts
+++ b/src/webparts/skillMatrix/components/ISkillMatrixProps.ts
@@ -1,0 +1,4 @@
+export interface ISkillMatrixProps {
+  /** Absolute URL of the current site (passed from web part) */
+  siteUrl: string;
+}

--- a/src/webparts/skillMatrix/components/SkillMatrix.module.scss
+++ b/src/webparts/skillMatrix/components/SkillMatrix.module.scss
@@ -1,0 +1,40 @@
+.skillMatrix {
+  .header {
+    background-color: #0078d4; // Classic SharePoint blue
+    color: #fff;
+    padding: 8px;
+    margin: 0;
+    text-align: center;
+    font-size: 1.2rem;
+    font-weight: 600;
+  }
+
+  .table {
+    width: 100%;
+    border-collapse: collapse;
+
+    thead {
+      tr {
+        th {
+          background-color: #0078d4;
+          color: #fff;
+          padding: 6px 4px;
+          text-align: left;
+        }
+      }
+    }
+
+    tbody {
+      tr {
+        &:nth-child(even) {
+          background-color: #f3f9fd;
+        }
+
+        td {
+          padding: 6px 4px;
+          border-bottom: 1px solid #c8c8c8;
+        }
+      }
+    }
+  }
+}

--- a/src/webparts/skillMatrix/components/SkillMatrix.tsx
+++ b/src/webparts/skillMatrix/components/SkillMatrix.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import { ISkillMatrixProps } from './ISkillMatrixProps';
+import { ISkillLogItem } from '../../../../models/ISkillLogItem';
+import styles from './SkillMatrix.module.scss';
+import { sp } from '@pnp/sp/presets/all';
+
+const LIST_NAME = 'SkillLogs';
+
+const SkillMatrix: React.FC<ISkillMatrixProps> = () => {
+  const [items, setItems] = React.useState<ISkillLogItem[]>([]);
+  const [loading, setLoading] = React.useState<boolean>(false);
+
+  const loadItems = async (): Promise<void> => {
+    setLoading(true);
+    try {
+      const data = await sp.web.lists
+        .getByTitle(LIST_NAME)
+        .items.select(
+          'Id',
+          'EmployeeEmail',
+          'Skills',
+          'ExpectedProficiency',
+          'ActualProficiency',
+          'ActionPlan',
+          'Timeline',
+          'SkillGap',
+          'Comments'
+        )
+        .get<ISkillLogItem[]>();
+
+      setItems(data);
+    } catch (error) {
+      console.error(`[SkillMatrix] Error loading items:`, error);
+    }
+    setLoading(false);
+  };
+
+  React.useEffect(() => {
+    loadItems();
+  }, []);
+
+  if (loading) {
+    return <div className={styles.skillMatrix}>Loading...</div>;
+  }
+
+  return (
+    <div className={styles.skillMatrix}>
+      <h2 className={styles.header}>Skill Matrix</h2>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Employee Email</th>
+            <th>Skills</th>
+            <th>Expected</th>
+            <th>Actual</th>
+            <th>Action Plan</th>
+            <th>Timeline</th>
+            <th>Skill Gap</th>
+            <th>Comments</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={item.Id}>
+              <td>{item.EmployeeEmail}</td>
+              <td>{item.Skills}</td>
+              <td>{item.ExpectedProficiency}</td>
+              <td>{item.ActualProficiency}</td>
+              <td>{item.ActionPlan}</td>
+              <td>{item.Timeline}</td>
+              <td>{item.SkillGap}</td>
+              <td>{item.Comments}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default SkillMatrix;


### PR DESCRIPTION
Add functionality to fetch and display data from the 'SkillLogs' SharePoint list in the web part.

---
<a href="https://cursor.com/background-agent?bcId=bc-c232bf1a-a780-4e1d-9f57-d328042e324a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c232bf1a-a780-4e1d-9f57-d328042e324a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

